### PR TITLE
docs: point Helm chart links at the v1.x branch

### DIFF
--- a/docs/install/installEverest.md
+++ b/docs/install/installEverest.md
@@ -18,7 +18,7 @@ export KUBECONFIG=~/.kube/config
 ## Install OpenEverest
 
 !!! info "Important"
-    Starting from version 1.4.0, `everestctl` now uses the [Helm chart](https://github.com/openeverest/helm-charts/tree/main/charts/everest){:target="_blank"} to install OpenEverest. To configure chart parameters during installation through `everestctl`, you can:
+    Starting from version 1.4.0, `everestctl` now uses the [Helm chart](https://github.com/openeverest/helm-charts/tree/v1.x/charts/everest){:target="_blank"} to install OpenEverest. To configure chart parameters during installation through `everestctl`, you can:
 
     * Use the `--helm.set` flag to specify individual parameter values.
     * Provide a values file with the `--helm.values` flag for bulk configuration.

--- a/docs/install/install_everest_and_expose_via_ingress.md
+++ b/docs/install/install_everest_and_expose_via_ingress.md
@@ -19,7 +19,7 @@ An Ingress Controller is a Kubernetes component that manages external access to 
 
 === "Install OpenEverest using Helm"
 
-    OpenEverest Helm charts are in the [openeverest/helm-charts](https://github.com/openeverest/helm-charts/tree/main/charts/everest){:target="_blank"} repository on GitHub.
+    OpenEverest Helm charts are in the [openeverest/helm-charts](https://github.com/openeverest/helm-charts/tree/v1.x/charts/everest){:target="_blank"} repository on GitHub.
 
     Here are the steps to install OpenEverest and deploy additional database namespaces:
     {.power-number}
@@ -151,7 +151,7 @@ An Ingress Controller is a Kubernetes component that manages external access to 
 === "Install OpenEverest using everesctl"
 
     !!! info "Important"
-        Starting from version 1.4.0, `everestctl` now uses the [Helm chart](https://github.com/openeverest/helm-charts/tree/main/charts/everest){:target="_blank"} to install OpenEverest. To configure chart parameters during installation through `everestctl`, you can:
+        Starting from version 1.4.0, `everestctl` now uses the [Helm chart](https://github.com/openeverest/helm-charts/tree/v1.x/charts/everest){:target="_blank"} to install OpenEverest. To configure chart parameters during installation through `everestctl`, you can:
         
         * Use the `--helm.set` flag to specify individual parameter values.
         * Provide a values file with the `--helm.values` flag for bulk configuration.

--- a/docs/install/install_everest_helm_charts.md
+++ b/docs/install/install_everest_helm_charts.md
@@ -2,7 +2,7 @@
 
 This section explains how to install OpenEverest using [Helm](https://helm.sh/){:target="_blank"} as an alternative to `everestctl`. Helm charts simplify the deployment process by packaging all necessary resources and configurations, making them ideal for automating and managing installations in Kubernetes environments.
 
-OpenEverest Helm charts can be found in [openeverest/helm-charts](https://github.com/openeverest/helm-charts/tree/main/charts/everest){:target="_blank"} repository in Github.
+OpenEverest Helm charts can be found in [openeverest/helm-charts](https://github.com/openeverest/helm-charts/tree/v1.x/charts/everest){:target="_blank"} repository in Github.
 
 !!! info "Important"
     If you installed OpenEverest using Helm, make sure to uninstall it exclusively through Helm for a seamless removal.

--- a/docs/quick-install.md
+++ b/docs/quick-install.md
@@ -2,7 +2,7 @@
 
 Helm simplifies the installation of OpenEverest. With this guide, you'll be up and running with OpenEverest in no time. However, we also have a comprehensive [installation guide](install/install_everest_helm_charts.md) that covers all possibilities.
 
-OpenEverest Helm charts can be found in [openeverest/helm-charts](https://github.com/openeverest/helm-charts/tree/main/charts/everest){:target="_blank"} repository in Github.
+OpenEverest Helm charts can be found in [openeverest/helm-charts](https://github.com/openeverest/helm-charts/tree/v1.x/charts/everest){:target="_blank"} repository in Github.
 
 !!! info "Alternative installation method"
     If you prefer an alternative method, you can [install OpenEverest using everestctl](install/installEverest.md).

--- a/docs/troubleshoot/faq.md
+++ b/docs/troubleshoot/faq.md
@@ -58,7 +58,7 @@ OpenEverest doesn't deploy PMM (Percona Monitoring and Management). However, you
 
 We configure PMM agents in each DB deployment to communicate with an existing PMM server.
 
-The following table shows the [configurable parameters](https://github.com/openeverest/helm-charts/tree/main/charts/everest#configuration){:target="_blank"} of OpenEverest chart and their default values.
+The following table shows the [configurable parameters](https://github.com/openeverest/helm-charts/tree/v1.x/charts/everest#configuration){:target="_blank"} of OpenEverest chart and their default values.
 
 ### Monitoring configuration highlights:
 

--- a/docs/troubleshoot/installation_overview.md
+++ b/docs/troubleshoot/installation_overview.md
@@ -7,9 +7,9 @@ This page provides an overview of how OpenEverest is installed, the components i
 
 Starting with OpenEverest v1.4.0, the [everestctl](../install/installEverest.md) is a wrapper around two helm charts:
 
-- [everest-core](https://github.com/openeverest/helm-charts/tree/main/charts/everest){:target="_blank"} 
+- [everest-core](https://github.com/openeverest/helm-charts/tree/v1.x/charts/everest){:target="_blank"} 
 
-- [everest-db-namespace](https://github.com/openeverest/helm-charts/tree/main/charts/everest/charts/everest-db-namespace){:target="_blank"}. 
+- [everest-db-namespace](https://github.com/openeverest/helm-charts/tree/v1.x/charts/everest/charts/everest-db-namespace){:target="_blank"}. 
 
 The installation flow is as follows:
 {.power-number}
@@ -72,9 +72,9 @@ everestctl namespaces update [NAMESPACE]
 everestctl namespaces remove [NAMESPACE]
 ```
 
-For detailed information on managing namespaces, see the [Namespaces management](https://github.com/openeverest/helm-charts/tree/main/charts/everest#4-deploy-additional-database-namespaces){:target="_blank"} section.
+For detailed information on managing namespaces, see the [Namespaces management](https://github.com/openeverest/helm-charts/tree/v1.x/charts/everest#4-deploy-additional-database-namespaces){:target="_blank"} section.
 
-The [helm installation method](../install/install_everest_helm_charts.md) provides an identical flow to the one described above, with similar configuration options. Refer to the [helm chart documentation](https://github.com/openeverest/helm-charts/tree/main/charts/everest){:target="_blank"} for a complete list of available [configuration options](https://github.com/openeverest/helm-charts/tree/main/charts/everest#configuration){:target="_blank"}.
+The [helm installation method](../install/install_everest_helm_charts.md) provides an identical flow to the one described above, with similar configuration options. Refer to the [helm chart documentation](https://github.com/openeverest/helm-charts/tree/v1.x/charts/everest){:target="_blank"} for a complete list of available [configuration options](https://github.com/openeverest/helm-charts/tree/v1.x/charts/everest#configuration){:target="_blank"}.
 
 ## Server and operator workflow
 
@@ -100,7 +100,7 @@ Here's the database creation workflow in OpenEverest:
 Here’s the workflow for the database engine in OpenEverest:
 {.power-number}
 
-1. You can install the `everest-db-namespace` chart either as part of the initial installation or as a [separate step](https://github.com/openeverest/helm-charts/tree/main/charts/everest#4-deploy-additional-database-namespaces).
+1. You can install the `everest-db-namespace` chart either as part of the initial installation or as a [separate step](https://github.com/openeverest/helm-charts/tree/v1.x/charts/everest#4-deploy-additional-database-namespaces).
 2. OLM subscriptions are created for the operators chosen while installing the Helm chart.
 3. OLM **reconciles the Subscriptions** and creates an **InstallPlan**.
 4. The Helm chart creates a Kubernetes job called `everest-operators-installer` that waits for the `InstallPlan` to be created and approves it.


### PR DESCRIPTION
**Step 6 of the branch swap. Do not merge until helm-charts has renamed `main` -> `v1.x`.**

openeverest/helm-charts#91 renames `main` -> `v1.x` and promotes `v2` to `main`. These pages document installing OpenEverest 1.x, so their chart links would silently start showing the **v2** chart — different values, different templates.

11 links across 6 pages repointed from `helm-charts/tree/main` to `helm-charts/tree/v1.x`.

Release-notes pages linking `percona/percona-helm-charts` are historical and left alone.