### PR TITLE
docs: fix Helm migration upgrade values

### DIFF
--- a/docs/upgrade/upgrade_with_helm.md
+++ b/docs/upgrade/upgrade_with_helm.md
@@ -46,21 +46,19 @@ To migrate, run the following commands:
 
     ```sh
     helm upgrade everest-core openeverest/openeverest \
-      --namespace everest-system \
-      --reset-then-reuse-values
+      --namespace everest-system
     ```
 
     If you have one or more database namespace releases, upgrade each one:
 
     ```sh
     helm upgrade <RELEASE_NAME> openeverest/everest-db-namespace \
-      --namespace <DB_NAMESPACE> \
-      --reset-then-reuse-values
+      --namespace <DB_NAMESPACE>
     ```
 
     Replace `<RELEASE_NAME>` and `<DB_NAMESPACE>` with your actual release name and namespace. To list all your current releases, run `helm list --all-namespaces`.
 
-    Use `--reset-then-reuse-values` instead of `--reuse-values` so new chart defaults (for fields introduced in the new chart version) are applied while your existing overrides are preserved. With `--reuse-values` alone, upgrades can fail when the chart adds required values that were not present in the previous release.
+    Do not pass `--reuse-values`. That flag replaces the new chart's defaults with the previous release's values, so new keys (for example `gatewayAPI.enabled`) stay unset and the upgrade can fail. With no `--set` or `-f`, `helm upgrade` already keeps your existing values and applies new chart defaults.
 
 4. (Optional) Remove the old Percona Helm repository once all releases have been migrated:
 
@@ -108,9 +106,7 @@ This ensures the CRDs are correctly recognized as managed by Helm, avoiding vali
 ## Upgrade Helm releases
 
 !!! warning
-    When using `helm upgrade`, specifying `--set` (or other equivalent flags) causes Helm to revert all other values to the defaults defined in the chart. To avoid this issue, either include `--reuse-values` / `--reset-then-reuse-values` or provide the complete set of values, including those used during the installation.
-
-    Prefer `--reset-then-reuse-values` when upgrading to a chart version that introduces new values. `--reuse-values` keeps only the previous release values and can fail template rendering if the new chart expects fields that were not set before (for example `gatewayAPI.enabled`).
+    When using `helm upgrade` with `--set` or `-f`, pass `--reset-then-reuse-values` (Helm 3.14.0 or later) so your overrides apply on top of the new chart's defaults. `--reuse-values` alone drops those defaults. Alternatively, pass the complete set of values used at install time.
 
 To upgrade OpenEverest using Helm, run the following commands:
 {.power-number}

--- a/docs/upgrade/upgrade_with_helm.md
+++ b/docs/upgrade/upgrade_with_helm.md
@@ -47,7 +47,7 @@ To migrate, run the following commands:
     ```sh
     helm upgrade everest-core openeverest/openeverest \
       --namespace everest-system \
-      --reuse-values
+      --reset-then-reuse-values
     ```
 
     If you have one or more database namespace releases, upgrade each one:
@@ -55,10 +55,12 @@ To migrate, run the following commands:
     ```sh
     helm upgrade <RELEASE_NAME> openeverest/everest-db-namespace \
       --namespace <DB_NAMESPACE> \
-      --reuse-values
+      --reset-then-reuse-values
     ```
 
     Replace `<RELEASE_NAME>` and `<DB_NAMESPACE>` with your actual release name and namespace. To list all your current releases, run `helm list --all-namespaces`.
+
+    Use `--reset-then-reuse-values` instead of `--reuse-values` so new chart defaults (for fields introduced in the new chart version) are applied while your existing overrides are preserved. With `--reuse-values` alone, upgrades can fail when the chart adds required values that were not present in the previous release.
 
 4. (Optional) Remove the old Percona Helm repository once all releases have been migrated:
 
@@ -106,7 +108,9 @@ This ensures the CRDs are correctly recognized as managed by Helm, avoiding vali
 ## Upgrade Helm releases
 
 !!! warning
-    When using `helm upgrade`, specifying `--set` (or other equivalent flags) causes Helm to revert all other values to the defaults defined in the chart. To avoid this issue, either include the `--reuse-values` flag or provide the complete set of values, including those used during the installation.
+    When using `helm upgrade`, specifying `--set` (or other equivalent flags) causes Helm to revert all other values to the defaults defined in the chart. To avoid this issue, either include `--reuse-values` / `--reset-then-reuse-values` or provide the complete set of values, including those used during the installation.
+
+    Prefer `--reset-then-reuse-values` when upgrading to a chart version that introduces new values. `--reuse-values` keeps only the previous release values and can fail template rendering if the new chart expects fields that were not set before (for example `gatewayAPI.enabled`).
 
 To upgrade OpenEverest using Helm, run the following commands:
 {.power-number}


### PR DESCRIPTION
## Summary
- Drop `--reuse-values` from the Percona → OpenEverest Helm migration steps (no `--set`/`‑f` on those commands).
- Document why `--reuse-values` breaks upgrades when new chart keys appear (e.g. `gatewayAPI.enabled`).
- Recommend `--reset-then-reuse-values` when upgrading with `--set` or `-f`.

Fixes openeverest/openeverest#2610