### PR TITLE
docs: use --reset-then-reuse-values on install Helm upgrades

### DIFF
--- a/docs/install/installEverest.md
+++ b/docs/install/installEverest.md
@@ -126,7 +126,7 @@ To install and provision OpenEverest to Kubernetes:
             ```sh
             helm upgrade everest openeverest/openeverest \
             --namespace everest-system \
-            --reuse-values \
+            --reset-then-reuse-values \
             --set server.service.type=LoadBalancer
             ```
                     
@@ -158,7 +158,7 @@ To install and provision OpenEverest to Kubernetes:
             ```sh
             helm upgrade everest openeverest/openeverest \
             --namespace everest-system \
-            --reuse-values \
+            --reset-then-reuse-values \
             --set server.service.type=NodePort
             ```
 

--- a/docs/install/install_everest_helm_charts.md
+++ b/docs/install/install_everest_helm_charts.md
@@ -91,7 +91,7 @@ Here are the steps to install OpenEverest and deploy additional database namespa
             ```sh
             helm upgrade everest-core openeverest/openeverest \
             --namespace everest-system \
-            --reuse-values \
+            --reset-then-reuse-values \
             --set server.service.type=LoadBalancer
             ```
                     
@@ -125,7 +125,7 @@ Here are the steps to install OpenEverest and deploy additional database namespa
             ```sh
             helm upgrade everest-core openeverest/openeverest \
             --namespace everest-system \
-            --reuse-values \
+            --reset-then-reuse-values \
             --set server.service.type=NodePort
             ```
             The following output displays the port assigned by Kubernetes to the everest service, which is `32349` in this case.


### PR DESCRIPTION
## Summary
Replace `--reuse-values` with `--reset-then-reuse-values` in LoadBalancer/NodePort `helm upgrade` examples that use `--set`.

Fixes openeverest/openeverest#3003